### PR TITLE
Added 3 new regex patterns

### DIFF
--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -61,7 +61,13 @@ psychobabble = [
     [r"Spielen wir (.*)(?:.{0,2})(?<![!?])",
     ["Endlich fragt mich jemand!! Ich liebe {0}.",
     "Ne, für {0} ist es mir leider zu spät. Ich muss noch DSAIIS abgeben.",
-    "Vielleicht am 25. Juni 2025. Eigentlich hab ich keine Zeit um {0} zu spielen, ich muss meine Haare waschen."]]
+    "Vielleicht am 25. Juni 2025. Eigentlich hab ich keine Zeit um {0} zu spielen, ich muss meine Haare waschen."]],
+
+    [r"Woher kommt (.*)(?:.{0,2})(?<![!?])",
+    ["Wo {0} herkommt? Woher soll ich das wissen?",
+    "{0} kommt aus den tiefsten Alpen.",
+    "{0} wurde zuerst in einer sumerischen Ruine gefunden, seitdem aber auch in Mexiko und der Mongolei."]]
+
 ]
 
 

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -56,9 +56,12 @@ psychobabble = [
     [r"was (macht|machen)(.*)(?<![\?\!\.\,\d\;])",
     ["Prinzipiell wird mit {1} nichts gemacht, wenn du dich ansträngst kann das aber bestimmt was werden!",
     "Puh weiss nicht, ich hab aber mal gelesen dass es unpraktisch sei, {1} zu haben, ohne zu wissen was gemacht wird",
-    "{1} {0} nicht viel ausser doof rumliegen :("]]
+    "{1} {0} nicht viel ausser doof rumliegen :("]],
 
-
+    [r"Spielen wir (.*)(?:.{0,2})(?<![!?])",
+    ["Endlich fragt mich jemand!! Ich liebe {0}.",
+    "Ne, für {0} ist es mir leider zu spät. Ich muss noch DSAIIS abgeben.",
+    "Vielleicht am 25. Juni 2025. Eigentlich hab ich keine Zeit um {0} zu spielen, ich muss meine Haare waschen."]]
 ]
 
 

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -51,7 +51,12 @@ psychobabble = [
     [r"Kannst du mir bei (.*) helfen",
      ["Was genau möchtest du über {0} wissen?",
     "Wie kann ich dir bei {0} behilflich sein?",
-    "Erzähl mir mehr über deine Fragen zu {0}."]]
+    "Erzähl mir mehr über deine Fragen zu {0}."]],
+
+    [r"was (macht|machen)(.*)(?<![\?\!\.\,\d\;])",
+    ["Prinzipiell wird mit {1} nichts gemacht, wenn du dich ansträngst kann das aber bestimmt was werden!",
+    "Puh weiss nicht, ich hab aber mal gelesen dass es unpraktisch sei, {1} zu haben, ohne zu wissen was gemacht wird",
+    "{1} {0} nicht viel ausser doof rumliegen :("]]
 
 
 ]


### PR DESCRIPTION
## What
I've added 3 new regex patterns to dailizabot/text_patterns.py.
Each pattern includes three possible responses that are either positive or negative

## Why?
While testing the bot I noticed some prompts were returning the default answer *"Das habe ich nicht verstanden. Bitte wiederhole es!"*.

## How?
1. `was (macht|machen)(.*)(?<![\?\!\.\,\d\;])` filter
    - `(macht|machen)`: Matches either "macht" or "machen".
    - `(.*)`: matches all following characters
    - `(?<![\?\!\.\,\d\;])`: negative lookbehind which compares the characters in the square brackets

2. `Spielen wir (.*)(?:.{0,2})(?<![!?])`
    - `(.*)`: matches all following characters
    - `(?<![\?\!\.\,\d\;])`: negative lookbehind which compares the characters in the square brackets
    - 
3. `Woher kommt (.*)(?:.{0,2})(?<![!?])`
    - `(.*)`: matches all following characters
    - `(?<![\?\!\.\,\d\;])`: negative lookbehind which compares the characters in the square brackets

[re Documentation for more indepth explanations](https://docs.python.org/3/library/re.html).

## Testing observations

I noticed that because of the complexity of the german grammatical cases, verb conjugation and singular/plural differentiation some answers would give out the incorrect grammatical syntax.
Fixing this would be out of scope for now, but it should be addressed in the future.

[German grammar](https://en.wikipedia.org/wiki/German_grammar)